### PR TITLE
Add initial governance documents

### DIFF
--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -63,8 +63,8 @@ with any questions.
 4. **Be respectful**. Not all of us will agree all the time, but disagreement is
    no excuse for poor behavior or poor manners. We might all experience some
    frustration now and then, but we cannot allow that frustration to turn into a
-   personal attack. It’s important to remember that a community where people
-   feel uncomfortable or threatened is not a productive one.
+   personal attack. A community where people feel uncomfortable or threatened is
+   not a productive one.
 
 5. **Be careful in the words that you choose**. Be kind to others. Do not insult
    or put down other community members. Harassment and other exclusionary
@@ -86,7 +86,7 @@ with any questions.
    expectations is preferable to demands for another person's time.
 
 7. **When we disagree, try to understand why**. Disagreements, both social and
-   technical, happen all the time and the GeoPandas Project is no exception. Try to
+   technical, happen all the time, and the GeoPandas Project is no exception. Try to
    understand where others are coming from, as seeing a question from their
    viewpoint may help find a new path forward. And don’t forget that it is
    human to err: blaming each other doesn’t get us anywhere, while we can learn

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -78,8 +78,8 @@ with any questions.
     - Personal insults, especially those using racist, sexist, and xenophobic terms
     - Unwelcome sexual attention
     - Advocating for, or encouraging, any of the above behavior
-    - Repeated harassment of others. In general, if someone asks you to stop,
-      then stop
+
+    **In general, if someone asks you to stop, then stop.**
 
 6. **Moderate your expectations**. Please respect that community members choose
    how they spend their time in the project. A thoughtful question about your

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -1,0 +1,133 @@
+# GeoPandas Project Code of Conduct
+
+Behind the GeoPandas Project is an engaged and respectful community made up of
+people from all over the world and with a wide range of backgrounds. Naturally,
+this implies diversity of ideas and perspectives on often complex problems.
+Disagreement and healthy discussion of conflicting viewpoints is welcome: the
+best solutions to hard problems rarely come from a single angle. But
+disagreement is not an excuse for aggression: humans tend to take disagreement
+personally and easily drift into behavior that ultimately degrades a community.
+This is particularly acute with online communication across language and
+cultural gaps, where many cues of human behavior are unavailable. We are
+outlining here a set of principles and processes to support a healthy community
+in the face of these challenges.
+
+Fundamentally, we are committed to fostering a productive, harassment-free
+environment for everyone. Rather than considering this code an exhaustive list
+of things that you can’t do, take it in the spirit it is intended - a guide to
+make it easier to enrich all of us and the communities in which we participate.
+
+Importantly: as a member of our community, _you are also a steward of these
+values_. Not all problems need to be resolved via formal processes, and often a
+quick, friendly but clear word on an online forum or in person can help resolve
+a misunderstanding and de-escalate things.
+
+However, sometimes these informal processes may be inadequate: they fail to
+work, there is urgency or risk to someone, nobody is intervening publicly and
+you don't feel comfortable speaking in public, etc. For these or other reasons,
+structured follow-up may be necessary and here we provide the means for that: we
+welcome reports by emailing
+[geopandas-conduct@googlegroups.com](mailto:geopandas-conduct@googlegroups.com)
+or by filling out
+[this form](https://docs.google.com/forms/d/e/1FAIpQLSd8Tbi2zNl1i2N9COX0yavHEqTGFIPQ1_cLcy1A3JgVc1OrAQ/viewform).
+
+This code applies equally to founders, developers, mentors and new community
+members, in all spaces managed by the GeoPandas Project. This includes the
+mailing lists, our GitHub organization, our chat room, in-person events, and any
+other forums created by the project team. In addition, violations of this code
+outside these spaces may affect a person's ability to participate within them.
+
+By embracing the following principles, guidelines and actions to follow or
+avoid, you will help us make the GeoPandas Project a welcoming and productive
+community. Feel free to contact the Code of Conduct Committee at
+[geopandas-conduct@googlegroups.com](mailto:geopandas-conduct@googlegroups.com)
+with any questions.
+
+1. **Be friendly and patient**.
+
+2. **Be welcoming**. We strive to be a community that welcomes and supports
+   people of all backgrounds and identities. This includes, but is not limited
+   to, members of any race, ethnicity, culture, national origin, color,
+   immigration status, social and economic class, educational level, sex, sexual
+   orientation, gender identity and expression, age, physical appearance, family
+   status, technological or professional choices, academic
+   discipline, religion, mental ability, and physical ability.
+
+3. **Be considerate**. Your work will be used by other people, and you in turn
+   will depend on the work of others. Any decision you take will affect users
+   and colleagues, and you should take those consequences into account when
+   making decisions. Remember that we're a world-wide community. You may be
+   communicating with someone with a different primary language or cultural
+   background.
+
+4. **Be respectful**. Not all of us will agree all the time, but disagreement is
+   no excuse for poor behavior or poor manners. We might all experience some
+   frustration now and then, but we cannot allow that frustration to turn into a
+   personal attack. It’s important to remember that a community where people
+   feel uncomfortable or threatened is not a productive one.
+
+5. **Be careful in the words that you choose**. Be kind to others. Do not insult
+   or put down other community members. Harassment and other exclusionary
+   behavior are not acceptable. This includes, but is not limited to:
+
+    - Violent threats or violent language directed against another person
+    - Discriminatory jokes and language
+    - Posting sexually explicit or violent material
+    - Posting (or threatening to post) other people's personally identifying
+      information ("doxing")
+    - Personal insults, especially those using racist, sexist, and xenophobic terms
+    - Unwelcome sexual attention
+    - Advocating for, or encouraging, any of the above behavior
+    - Repeated harassment of others. In general, if someone asks you to stop,
+      then stop
+
+6. **Moderate your expectations**. Please respect that community members choose
+   how they spend their time in the project. A thoughtful question about your
+   expectations is preferable to demands for another person's time.
+
+7. **When we disagree, try to understand why**. Disagreements, both social and
+   technical, happen all the time and the GeoPandas Project is no exception. Try to
+   understand where others are coming from, as seeing a question from their
+   viewpoint may help find a new path forward. And don’t forget that it is
+   human to err: blaming each other doesn’t get us anywhere, while we can learn
+   from mistakes to find better solutions.
+
+8. **A simple apology can go a long way**. It can often de-escalate a situation,
+   and telling someone that you are sorry is an act of empathy that doesn’t
+   automatically imply an admission of guilt.
+
+## Reporting
+
+If you believe someone is violating the code of conduct, please report this in
+a timely manner. Code of conduct violations reduce the value of the community
+for everyone and we take them seriously.
+
+You can file a report by emailing
+[geopandas-conduct@googlegroups.com](mailto:geopandas-conduct@googlegroups.com)
+or by filing out
+[this form](https://docs.google.com/forms/d/e/1FAIpQLSd8Tbi2zNl1i2N9COX0yavHEqTGFIPQ1_cLcy1A3JgVc1OrAQ/viewform).
+
+The online form gives you the option to keep your report anonymous or request
+that we follow up with you directly. While we cannot follow up on an anonymous
+report, we will take appropriate action.
+
+Messages sent to the e-mail address or through the form will be sent only to the
+Code of Conduct Committee. Code of Conduct Committee Members are listed
+[here](./membership/CodeOfConductSubcommittee.md).
+
+## Enforcement
+
+Enforcement procedures within the GeoPandas Project follow Project Jupyter's
+[Enforcement Manual](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md).
+For information on enforcement, please view the
+[original manual](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md).
+
+Original text courtesy of the
+[Speak Up!](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html),
+[Django](https://www.djangoproject.com/conduct) and
+[Jupyter](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md)
+projects, modified by the GeoPandas Project. We are grateful to those projects
+for contributing these materials under open licensing terms for us to easily
+reuse.
+
+All content on this page is licensed under a [Creative Commons Attribution](http://creativecommons.org/licenses/by/3.0/) license.

--- a/Governance.md
+++ b/Governance.md
@@ -21,15 +21,17 @@ The primary goal of The Project is to develop support for geospatial data in
 is released under the BSD (or similar) open source license, developed openly,
 and hosted on public GitHub repositories under the
 [GeoPandas GitHub organization](https://github.com/geopandas).
-In addition to the main [GeoPandas repository](https://github.com/geopandas/geopandas),
-the GeoPandas project includes subprojects focused on geospatial I/O, geospatial
-data exploration and visualization, and parallelized geospatial computations.
+In addition to the main
+[GeoPandas repository](https://github.com/geopandas/geopandas),
+the GeoPandas project includes subprojects focused on geospatial input/output,
+geospatial data exploration and visualization, and parallelized geospatial
+computations.
 
 The Project is developed by a team of distributed Contributors. Contributors are
 individuals who have contributed code, participated in GitHub Issues, Pull
 Requests, and Discussions, or provided community help/building, education,
 outreach, and other activities that benefit the Project and the Community.
-Anyone can be a Contributor, and contributors can be affiliated with any legal
+Anyone can be a Contributor, and Contributors can be affiliated with any legal
 entity or none.
 
 The Project Community consists of all Contributors and Users of The Project.
@@ -116,7 +118,7 @@ solution that everyone can live with.
 If all proposals for resolving some issue are vetoed, then the status quo wins
 by default. In the worst case, if a Contributor is genuinely misusing their veto
 in an obstructive fashion to the detriment of the project, then they can be
-ejected from the project by consensus of the Steering Council – see below.
+ejected from the project by consensus of the Steering Council.
 
 For more information about the overall approach we use to achieve consensus, we
 highly recommend that all Contributors additionally read
@@ -240,8 +242,8 @@ members, and their vacancy will be filled in the process outlined above.
 
 The Council reserves the right to eject current Members if they are deemed to be
 actively harmful to The Project's well-being, and attempts at communication and
-conflict resolution have failed. This requires the consensus of the remaining
-Members.
+conflict resolution have failed. This requires the consensus (as described above)
+of the remaining Members.
 
 Current and retired Steering Council Members will be listed on
 [Steering Council Membership document](./membership/SteeringCouncil.md).

--- a/Governance.md
+++ b/Governance.md
@@ -1,0 +1,323 @@
+# GeoPandas Project Governance
+
+## Summary
+
+GeoPandas is a community-owned and community-run project. To the maximum extent
+possible, decisions about project direction are made by community consensus.
+Some members of the community additionally contribute by serving as [GeoPandas
+Project Maintainers](#project-maintainers), where they are responsible for
+facilitating the everyday activities of the project, or on the
+[GeoPandas Steering Council](#steering-council), where they are
+responsible for facilitating the establishment of community consensus, for
+stewarding project resources, and – in extreme cases – for making project
+decisions if the normal community-based process breaks down.
+
+## The Project
+
+The GeoPandas Project (The Project) is an open source software project
+affiliated with the 501(c)3 [NumFOCUS Foundation](https://numfocus.org/).
+The primary goal of The Project is to develop support for geospatial data in
+[Pandas](https://pandas.pydata.org/) objects. Software developed by The Project
+is released under the BSD (or similar) open source license, developed openly,
+and hosted on public GitHub repositories under the
+[GeoPandas GitHub organization](https://github.com/geopandas).
+In addition to the main [GeoPandas repository](https://github.com/geopandas/geopandas),
+the GeoPandas project includes subprojects focused on geospatial I/O, geospatial
+data exploration and visualization, and parallelized geospatial computations.
+
+The Project is developed by a team of distributed Contributors. Contributors are
+individuals who have contributed code, participated in GitHub Issues, Pull
+Requests, and Discussions, or provided community help/building, education,
+outreach, and other activities that benefit the Project and the Community.
+Anyone can be a Contributor, and contributors can be affiliated with any legal
+entity or none.
+
+The Project Community consists of all Contributors and Users of The Project.
+Contributors work on behalf of and are responsible to the larger Project
+Community and we strive to keep the barrier between Contributors and Users as
+low as possible.
+
+Anyone can participate in The Project by submitting, reviewing, and offering
+feedback on GitHub Issues, Pull Requests, and/or Discussions, or by
+communicating through the Gitter chat room, mailing lists, and other channels.
+All members of the Community are welcome to participate in regular GeoPandas
+Community Meetings that occur online on a monthly basis. The schedule and
+archive of meeting notes are available within the [GeoPandas Community
+repository](https://github.com/geopandas/community).
+
+Participation in The Project follows the
+[GeoPandas Project Code of Conduct](./CodeOfConduct.md),
+which ensures that members of the Community treat each other with respect,
+provide an environment that welcomes participation, and provides a mechanism for
+reporting and enforcing violations.
+
+The Project is integrated within the larger Python data science and geospatial
+communities, and project Contributors are often involved in the ongoing
+maintenance, expansion, and creation of software projects within the
+broader ecosystem.
+
+## Governance
+
+The foundations of Project governance are:
+
+-   Openness and transparency
+-   Active contribution
+-   Institutional neutrality
+
+### Consensus-based decision-making by the community
+
+Normally, project decisions will be made by consensus of all interested
+Contributors. The primary goal of this approach is to ensure that the people who
+are most affected by and/or involved in any given change can contribute their
+knowledge in the confidence that their perspective will be acknowledged.
+Thoughtful review from a broad community is the best mechanism we know of for
+creating high-quality software.
+
+In this context, consensus does not require:
+
+-   that we solicit everybody's opinion on every change
+-   that we ever hold a vote on anything
+-   that everybody is happy or agrees with every decision
+
+Consensus means that we entrust everyone with the right to veto any change if
+they feel it necessary.
+
+To achieve consensus, we use a combination of best judgment and best efforts:
+
+-   A simple and uncontroversial bug fix posted on GitHub and reviewed by a core
+    developer is probably fine.
+-   Substantive or controversial API changes may involve one or more GitHub
+    issues, Pull Requests, or Discussions that are open for longer periods of
+    time to provide greater opportunity for feedback from the Community and may
+    specifically solicit feedback from targeted members of the Community.
+
+We expect that anyone who cares enough about The Project will raise their
+concerns or express their formal veto within one of these channels within a
+reasonably short period of time (up to a few weeks). If no major unresolved
+concerns exist after a period of time appropriate for the scope of the change,
+we will assume that consensus has been reached. If we find that a given change
+is more controversial than expected or a critical input is delayed because
+someone was unavailable, we can back out or further modify those changes based
+on the additional feedback.
+
+If necessary, a formal veto should consist of:
+
+-   an unambiguous statement that a veto is being invoked
+-   an explanation of why it is being invoked
+-   a description of what conditions (if any) would convince the vetoer to
+    withdraw their veto
+
+We expect that most people will take this responsibility seriously and only
+invoke their veto when they judge that a serious problem is being ignored and
+that their veto is necessary to protect The Project. We expect such vetoes to be
+rare in practice because Contributors are motivated from the start to find some
+solution that everyone can live with.
+
+If all proposals for resolving some issue are vetoed, then the status quo wins
+by default. In the worst case, if a Contributor is genuinely misusing their veto
+in an obstructive fashion to the detriment of the project, then they can be
+ejected from the project by consensus of the Steering Council – see below.
+
+For more information about the overall approach we use to achieve consensus, we
+highly recommend that all Contributors additionally read
+[Chapter 4: Social and Political Infrastructure](http://producingoss.com/en/producingoss.html#social-infrastructure)
+of Karl Fogel's classic Producing Open Source Software, and in particular the
+section on
+[Consensus-based Democracy](http://producingoss.com/en/producingoss.html#consensus-democracy),
+for a more detailed discussion.
+
+### Project Maintainers
+
+Project Maintainers are Project Contributors that have shown that they are
+dedicated to the ongoing development of the project through active engagement
+with the Community and facilitation of everyday Project activities. Maintainers
+are granted write access to one or more repositories within The Project, provide
+feedback on Github Issues and Discussions, review and merge Pull Requests,
+participate in monthly Community Meetings, vote on Steering Council members, and
+may be actively involved in setting the overall direction of the project.
+Project Maintainers are nominated by other Project Maintainers by sending a
+notification to the Project Maintainer's private mailing list. Other Project
+Maintainers will have a period of at least two weeks in which to veto a
+nomination; otherwise, the nominee shall become a Project Maintainer. No voting
+is necessary for selecting Project Maintainers.
+
+Project Maintainers who have not actively contributed to The Project for a
+period of 12 months will be asked if they wish to resign their write access and
+voting rights until they become active again.
+
+Project Maintainers may have their write access and voting rights revoked by the
+Steering Council if they are deemed to be actively harmful to The Project's
+well-being, and attempts at communication and conflict resolution have failed.
+
+Current and retired Project Maintainers will be
+[listed by subproject](./membership/Maintainers.md).
+
+To the maximum extent possible, the communications and activities of Project
+Maintainers are conducted publicly within the channels described above. Project
+Maintainers will have a private mailing list that may be used for topics that
+are sensitive in nature, such as the nomination of new Project Maintainers, or
+time-sensitive topics, such as grant application deadlines of interest to the
+Community, or to start initial work on project-related materials before opening
+those more broadly for input within the GeoPandas community. These topics and
+materials are then typically discussed and distributed as part of the monthly
+development meetings or related communication activities.
+
+In general, Pull Requests should be approved by at least one maintainer that did
+not submit the Pull Request, but are not required for especially small or
+trivial changes such as typo fixes.
+
+### Steering Council
+
+The Project will have a Steering Council that consists of Project Contributors
+who have produced contributions that are substantial in quality and quantity and
+sustained over a period of time sufficient to demonstrate their understanding of
+the needs of the project and community. The overall role of the Council is to
+ensure – with input from the Community – the long-term well-being of the
+project, both technically and as a community.
+
+Council Members participate in everyday project activities, including
+discussions and code review, as peers with all other Contributors and the
+Community. Council Members do not have any special power or privilege through
+their membership on the Council when participating in these everyday activities.
+However, it is expected that because of the quality and quantity of their
+contributions and their expert knowledge of the Project, Council Members will
+provide useful guidance, both technical and in terms of project direction, to
+potentially less experienced Contributors.
+
+If necessary, The Steering Council may:
+
+-   make decisions about the overall scope, vision, and direction of the project
+-   make decisions about strategic collaborations with other organizations or
+    individuals
+-   make decisions about specific technical issues, features, bugs, and Pull
+    Requests
+-   make decisions when regular community discussion doesn't produce consensus
+    on an issue in a reasonable time frame
+-   update policy documents such as this one
+
+However, the Council's primary responsibility is to facilitate the ordinary
+community-based decision-making procedure described above. If we ever have to
+step in and formally override the Community for the health of the Project, then
+we will do so, but we will consider reaching this point to indicate a failure in
+our leadership.
+
+#### Council Membership
+
+The Steering Council is composed of up to 5 Members that serve for 2-year terms.
+Council Members are nominated by Project Maintainers or themselves. Project
+Maintainers will vote on nominees during a voting period of at least one week
+that is announced sufficiently far in advance (e.g., 1 month) to ensure that all
+Project Maintainers that wish to vote are able to do so. No quorum of Project
+Maintainers is necessary for this voting process.
+
+The Council will be initially formed from the set of existing Project
+Maintainers who, as of mid-2022, have been significantly active over the last
+year.
+
+To become eligible to join the Steering Council, an individual must be a Project
+Contributor who has produced contributions that are substantial in quality and
+quantity, and sustained over a period of time sufficient to demonstrate their
+understanding of the needs of the project and community. These contributions may
+include, but are not limited to code, code review, participation in GitHub
+Issues, Pull Requests, and Discussions, community help/building, education,
+outreach, and other activities that benefit the Project and the Community. We
+want to encourage a diverse array of backgrounds, talents, and perspectives on
+the Council, which is why we explicitly do not define code or code-related
+metrics as the sole metric on which Council membership will be evaluated.
+
+Any former Council member can be considered for membership again at any time in
+the future, like any other Project Contributor; there is no maximum term length.
+
+If a Council member becomes inactive in the project for a period of one year,
+they will be considered for removal from the Council. Before removal, they will
+be contacted to determine if they plan on returning to active participation. If
+not, they will be removed immediately upon a vote of the remaining Council
+members, and their vacancy will be filled in the process outlined above.
+
+The Council reserves the right to eject current Members if they are deemed to be
+actively harmful to The Project's well-being, and attempts at communication and
+conflict resolution have failed. This requires the consensus of the remaining
+Members.
+
+Current and retired Steering Council Members will be listed on
+[Steering Council Membership document](./membership/SteeringCouncil.md).
+
+To the maximum extent possible, Council discussions and activities will be
+public and done in collaboration and discussion with the Project Contributors
+and Community. The Council will have a private mailing list that will be used
+sparingly and only when a specific matter requires privacy. When private
+communications and decisions are needed, the Council will do its best to
+summarize those to the Community after eliding personal/private/sensitive
+information that should not be posted to the public internet.
+
+#### Conflict of Interest
+
+It is expected that the Council Members will be employed at a wide range of
+companies, universities, and non-profit organizations. Because of this, it is
+possible that Members will have conflicts of interest. Such conflict of
+interests include, but are not limited to:
+
+-   financial interests, such as investments, employment, or contracting work,
+    outside of The Project that may influence their work on The Project
+-   access to proprietary information of their employer that could potentially
+    leak into their work with The Project
+
+All members of the Council shall disclose to the rest of the Council any
+conflict of interest they may have. Members with a conflict of interest in a
+particular issue may participate in Council discussions on that issue but must
+recuse themselves from voting on the issue.
+
+#### Subcommittees
+
+The Council can create subcommittees that provide leadership and guidance for
+specific aspects of the project. Subcommittees may include non-Council members
+as appropriate. Like the Council as a whole, subcommittees should conduct their
+business in an open and public manner unless privacy is specifically called for.
+Private subcommittee communications should happen on the main private mailing
+list of the Council unless specifically called for.
+
+The Project shall have a Code of Conduct Subcommittee responsible for
+maintaining the [GeoPandas Code of Conduct](CodeOfConduct.md), responding to
+reports of Code of Conduct Violations, and enforcing Code of Conduct Violations.
+This subcommittee shall not be entirely composed of Steering Council Members.
+The members of the Code of Conduct Subcommittee shall be posted on the
+[Code of Conduct Subcommittee Membership document](membership/CodeOfConductSubcommittee.md).
+
+## Changing the Governance Documents
+
+We anticipate that changes to these Governance documents will be rare and will
+warrant careful consideration, except in the case of typos or minor language
+errors.
+
+Any member of the Community may suggest a change to these Governance documents
+by opening a GitHub Issue on the GeoPandas Governance repository. The Steering
+Council may elect not to pursue changes outlined in the issue and may close the
+issue with a brief explanation of that choice.
+
+A member of the Steering Council may then formulate a GitHub Pull Request with
+specific changes to these Governance documents. The Steering Council may solicit
+input from the person that initially raised the issue and/or other members of
+the Community. Only Steering Council members may open a Pull Request on this
+repository. Pull Requests by any other Contributor (except in the case of very
+minor typo or language fixes) may be immediately closed by the Steering Council
+without further explanation.
+
+Members of the Steering Council then approve or veto the final version of the
+Pull Request. Once approved, the Pull Request will be merged and the updated
+Governance documents will be posted publicly within this repository.
+
+## Acknowledgements
+
+Text adapted from [Jupyter](https://jupyter.org/governance/governance.html),
+[NumPy](https://numpy.org/doc/stable/dev/governance/governance.html), and
+[Pandas](https://github.com/pandas-dev/pandas-governance/blob/master/governance.md)
+projects and modified by the GeoPandas Project. We are grateful to those
+projects for contributing these materials under open licensing terms for us to
+easily reuse.
+
+## License
+
+To the extent possible under law, the authors have waived all copyright and
+related or neighboring rights to this document, as per the
+[Creative Commons Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/)
+license.

--- a/Governance.md
+++ b/Governance.md
@@ -131,15 +131,16 @@ for a more detailed discussion.
 Project Maintainers are Project Contributors that have shown that they are
 dedicated to the ongoing development of the project through active engagement
 with the Community and facilitation of everyday Project activities. Maintainers
-are granted write access to one or more repositories within The Project, provide
-feedback on Github Issues and Discussions, review and merge Pull Requests,
-participate in monthly Community Meetings, vote on Steering Council members, and
-may be actively involved in setting the overall direction of the project.
-Project Maintainers are nominated by other Project Maintainers by sending a
-notification to the Project Maintainer's private mailing list. Other Project
-Maintainers will have a period of at least two weeks in which to veto a
-nomination; otherwise, the nominee shall become a Project Maintainer. No voting
-is necessary for selecting Project Maintainers.
+are typically granted write access to one or more repositories within The
+Project, provide feedback on Github Issues and Discussions, review and merge
+Pull Requests, participate in monthly Community Meetings (which are open to all
+community members), vote on Steering Council members, and may be actively
+involved in setting the overall direction of the project. Project Maintainers
+are nominated by other Project Maintainers by sending a notification to the
+Project Maintainer's private mailing list. Other Project Maintainers will have a
+period of at least two weeks in which to veto a nomination; otherwise, the
+nominee shall become a Project Maintainer. No voting is necessary for selecting
+Project Maintainers.
 
 Project Maintainers who have not actively contributed to The Project for a
 period of 12 months will be asked if they wish to resign their write access and
@@ -148,6 +149,9 @@ voting rights until they become active again.
 Project Maintainers may have their write access and voting rights revoked by the
 Steering Council if they are deemed to be actively harmful to The Project's
 well-being, and attempts at communication and conflict resolution have failed.
+Depending on the nature of the conflict, if any, the Code of Conduct
+Subcommittee may be involved in conflict resolution or specifically recommend
+revoking a Maintainer's write access and voting rights.
 
 Current and retired Project Maintainers will be
 [listed by subproject](./membership/Maintainers.md).
@@ -290,17 +294,13 @@ warrant careful consideration, except in the case of typos or minor language
 errors.
 
 Any member of the Community may suggest a change to these Governance documents
-by opening a GitHub Issue on the GeoPandas Governance repository. The Steering
-Council may elect not to pursue changes outlined in the issue and may close the
-issue with a brief explanation of that choice.
+by opening a GitHub Issue or Pull Request on the GeoPandas Governance
+repository. The Steering Council may elect not to pursue changes outlined in the
+Issue or Pull Request and may close the issue with a brief explanation of that
+choice.
 
-A member of the Steering Council may then formulate a GitHub Pull Request with
-specific changes to these Governance documents. The Steering Council may solicit
-input from the person that initially raised the issue and/or other members of
-the Community. Only Steering Council members may open a Pull Request on this
-repository. Pull Requests by any other Contributor (except in the case of very
-minor typo or language fixes) may be immediately closed by the Steering Council
-without further explanation.
+The Steering Council may solicit input from the person that initially raised the
+Issue or Pull Request and/or other members of the Community.
 
 Members of the Steering Council then approve or veto the final version of the
 Pull Request. Once approved, the Pull Request will be merged and the updated

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# governance
-GeoPandas project governance process
+# GeoPandas Project Governance Documents
+
+This repository contains documents related to governance of the GeoPandas
+project and subprojects.
+
+## Table of Contents
+
+-   [Project Governance](./Governance.md)
+-   [Code of Conduct](./CodeOfConduct.md)
+
+## Project Roles
+
+-   [Steering Council](./membership/SteeringCouncil.md)
+-   [Project Maintainers](./membership/Maintainers.md)
+-   [Code of Conduct Committee](./membership/CodeOfConductCommittee.md)
+
+For more information about the GeoPandas project community, including recurring
+meeting schedules and other ways to engage with the project, please see the
+[GeoPandas Community repository](https://github.com/geopandas/community).

--- a/membership/CodeOfConductCommittee.md
+++ b/membership/CodeOfConductCommittee.md
@@ -1,0 +1,8 @@
+# GeoPandas Code of Conduct Committee Members
+
+-   Hannah Aizenman
+-   Joris Van den Bossche
+-   Martin Fleischmann
+
+See the [Code of Conduct](../CodeOfConduct.md) for more information about the
+Code of Conduct, including reporting Code of Conduct violations.

--- a/membership/Maintainers.md
+++ b/membership/Maintainers.md
@@ -4,8 +4,8 @@ The list of Maintainers is managed at the subproject level. Not all subprojects
 have created a list of Maintainers yet. The list of subproject Maintainers will
 be listed here once available.
 
-[GeoPandas repository maintainers](https://geopandas.org/en/stable/about/team.html)
+[GeoPandas repository maintainers](https://geopandas.org/en/latest/about/team.html)
 
 [Contextily contributors](https://contextily.readthedocs.io/en/latest/#contributors)
 
-[xyzservices contributors](https://xyzservices.readthedocs.io/en/stable/#contributors)
+[xyzservices contributors](https://xyzservices.readthedocs.io/en/latest/#contributors)

--- a/membership/Maintainers.md
+++ b/membership/Maintainers.md
@@ -4,8 +4,22 @@ The list of Maintainers is managed at the subproject level. Not all subprojects
 have created a list of Maintainers yet. The list of subproject Maintainers will
 be listed here once available.
 
-[GeoPandas repository maintainers](https://geopandas.org/en/latest/about/team.html)
+## GeoPandas repository maintainers:
+
+-   Joris Van den Bossche
+-   Martin Fleischmann
+-   Matt Richards
+-   Brendan Ward
+-   Levi John Wolf
+-   James McBride
+
+See also [GeoPandas team](https://geopandas.org/en/latest/about/team.html) for
+more information about other GeoPandas contributors.
+
+## Contextily
 
 [Contextily contributors](https://contextily.readthedocs.io/en/latest/#contributors)
+
+## xyzservices
 
 [xyzservices contributors](https://xyzservices.readthedocs.io/en/latest/#contributors)

--- a/membership/Maintainers.md
+++ b/membership/Maintainers.md
@@ -1,0 +1,11 @@
+# GeoPandas Project Maintainers
+
+The list of Maintainers is managed at the subproject level. Not all subprojects
+have created a list of Maintainers yet. The list of subproject Maintainers will
+be listed here once available.
+
+[GeoPandas repository maintainers](https://geopandas.org/en/stable/about/team.html)
+
+[Contextily contributors](https://contextily.readthedocs.io/en/latest/#contributors)
+
+[xyzservices contributors](https://xyzservices.readthedocs.io/en/stable/#contributors)

--- a/membership/SteeringCouncil.md
+++ b/membership/SteeringCouncil.md
@@ -1,4 +1,11 @@
 # GeoPandas Project Steering Council
 
-The membership of the GeoPandas Steering Council has not yet been formally
-established. The list of members will be posted here once available.
+-   Joris Van den Bossche
+-   Martin Fleischmann
+-   Matt Richards
+-   Brendan Ward
+
+(last updated: October 12, 2022)
+
+See Project [Governance](../Governance.md#steering-council) for more information
+about the Steering Council.

--- a/membership/SteeringCouncil.md
+++ b/membership/SteeringCouncil.md
@@ -1,0 +1,4 @@
+# GeoPandas Project Steering Council
+
+The membership of the GeoPandas Steering Council has not yet been formally
+established. The list of members will be posted here once available.


### PR DESCRIPTION
This adds a Governance document adapted from Jupyter, NumPy, and Pandas projects.

This adds a copy of the Code of Conduct from the Geopandas subproject, with the following changes:
- changed line wrapping to fit standard used here (80 chars)
- moved the list of Code of Conduct committee members to dedicated document so that maintaining that list does not require updating the Code of Conduct

The intent is that the rarely changed top-level lists of members for various roles (Steering Council, Code of Conduct Committee) should live here, but that the specific lists of maintainers should be maintained on a subproject basis for easier maintenance.