### PR TITLE
Use NumFOCUS Code of Conduct

### DIFF
--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -2,7 +2,7 @@
 
 You can find the whole document here [https://numfocus.org/code-of-conduct](https://numfocus.org/code-of-conduct).
 
-## The short vertion
+## The short version
 
 NumFOCUS is dedicated to providing a harassment-free community for everyone, regardless of gender, sexual orientation, gender identity and expression, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of community members in any form.
 

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -1,133 +1,27 @@
-# GeoPandas Project Code of Conduct
+# NumFOCUS Code of Conduct
 
-Behind the GeoPandas Project is an engaged and respectful community made up of
-people from all over the world and with a wide range of backgrounds. Naturally,
-this implies diversity of ideas and perspectives on often complex problems.
-Disagreement and healthy discussion of conflicting viewpoints is welcome: the
-best solutions to hard problems rarely come from a single angle. But
-disagreement is not an excuse for aggression: humans tend to take disagreement
-personally and easily drift into behavior that ultimately degrades a community.
-This is particularly acute with online communication across language and
-cultural gaps, where many cues of human behavior are unavailable. We are
-outlining here a set of principles and processes to support a healthy community
-in the face of these challenges.
+You can find the whole document here [https://numfocus.org/code-of-conduct](https://numfocus.org/code-of-conduct).
 
-Fundamentally, we are committed to fostering a productive, harassment-free
-environment for everyone. Rather than considering this code an exhaustive list
-of things that you can’t do, take it in the spirit it is intended - a guide to
-make it easier to enrich all of us and the communities in which we participate.
+## The short vertion
 
-Importantly: as a member of our community, _you are also a steward of these
-values_. Not all problems need to be resolved via formal processes, and often a
-quick, friendly but clear word on an online forum or in person can help resolve
-a misunderstanding and de-escalate things.
+NumFOCUS is dedicated to providing a harassment-free community for everyone, regardless of gender, sexual orientation, gender identity and expression, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of community members in any form.
 
-However, sometimes these informal processes may be inadequate: they fail to
-work, there is urgency or risk to someone, nobody is intervening publicly and
-you don't feel comfortable speaking in public, etc. For these or other reasons,
-structured follow-up may be necessary and here we provide the means for that: we
-welcome reports by emailing
-[geopandas-conduct@googlegroups.com](mailto:geopandas-conduct@googlegroups.com)
-or by filling out
-[this form](https://docs.google.com/forms/d/e/1FAIpQLSd8Tbi2zNl1i2N9COX0yavHEqTGFIPQ1_cLcy1A3JgVc1OrAQ/viewform).
+Be kind to others. Do not insult or put down others. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for NumFOCUS.
 
-This code applies equally to founders, developers, mentors and new community
-members, in all spaces managed by the GeoPandas Project. This includes the
-mailing lists, our GitHub organization, our chat room, in-person events, and any
-other forums created by the project team. In addition, violations of this code
-outside these spaces may affect a person's ability to participate within them.
+All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate.
 
-By embracing the following principles, guidelines and actions to follow or
-avoid, you will help us make the GeoPandas Project a welcoming and productive
-community. Feel free to contact the Code of Conduct Committee at
-[geopandas-conduct@googlegroups.com](mailto:geopandas-conduct@googlegroups.com)
-with any questions.
+Thank you for helping make this a welcoming, friendly community for all.
 
-1. **Be friendly and patient**.
+## Long version
 
-2. **Be welcoming**. We strive to be a community that welcomes and supports
-   people of all backgrounds and identities. This includes, but is not limited
-   to, members of any race, ethnicity, culture, national origin, color,
-   immigration status, social and economic class, educational level, sex, sexual
-   orientation, gender identity and expression, age, physical appearance, family
-   status, technological or professional choices, academic
-   discipline, religion, mental ability, and physical ability.
+You can find the long version of the Code of Conduct on the NumFOCUS website [https://numfocus.org/code-of-conduct](https://numfocus.org/code-of-conduct)
 
-3. **Be considerate**. Your work will be used by other people, and you in turn
-   will depend on the work of others. Any decision you take will affect users
-   and colleagues, and you should take those consequences into account when
-   making decisions. Remember that we're a world-wide community. You may be
-   communicating with someone with a different primary language or cultural
-   background.
+## How to report
 
-4. **Be respectful**. Not all of us will agree all the time, but disagreement is
-   no excuse for poor behavior or poor manners. We might all experience some
-   frustration now and then, but we cannot allow that frustration to turn into a
-   personal attack. A community where people feel uncomfortable or threatened is
-   not a productive one.
+If you feel that the Code of Conduct has been violated, feel free to submit a report, by using the form: [NumFOCUS Code of Conduct Reporting Form](https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org)  
 
-5. **Be careful in the words that you choose**. Be kind to others. Do not insult
-   or put down other community members. Harassment and other exclusionary
-   behavior are not acceptable. This includes, but is not limited to:
+## Who will receive your report
 
-    - Violent threats or violent language directed against another person
-    - Discriminatory jokes and language
-    - Posting sexually explicit or violent material
-    - Posting (or threatening to post) other people's personally identifying
-      information ("doxing")
-    - Personal insults, especially those using racist, sexist, and xenophobic terms
-    - Unwelcome sexual attention
-    - Advocating for, or encouraging, any of the above behavior
+Your report will be received and handled by NumFOCUS Code of Conduct Working Group; trained, and experienced contributors with diverse backgrounds. The group is making decisions independently from the project, PyData, NumFOCUS or any other organization.
 
-    **In general, if someone asks you to stop, then stop.**
-
-6. **Moderate your expectations**. Please respect that community members choose
-   how they spend their time in the project. A thoughtful question about your
-   expectations is preferable to demands for another person's time.
-
-7. **When we disagree, try to understand why**. Disagreements, both social and
-   technical, happen all the time, and the GeoPandas Project is no exception. Try to
-   understand where others are coming from, as seeing a question from their
-   viewpoint may help find a new path forward. And don’t forget that it is
-   human to err: blaming each other doesn’t get us anywhere, while we can learn
-   from mistakes to find better solutions.
-
-8. **A simple apology can go a long way**. It can often de-escalate a situation,
-   and telling someone that you are sorry is an act of empathy that doesn’t
-   automatically imply an admission of guilt.
-
-## Reporting
-
-If you believe someone is violating the code of conduct, please report this in
-a timely manner. Code of conduct violations reduce the value of the community
-for everyone and we take them seriously.
-
-You can file a report by emailing
-[geopandas-conduct@googlegroups.com](mailto:geopandas-conduct@googlegroups.com)
-or by filing out
-[this form](https://docs.google.com/forms/d/e/1FAIpQLSd8Tbi2zNl1i2N9COX0yavHEqTGFIPQ1_cLcy1A3JgVc1OrAQ/viewform).
-
-The online form gives you the option to keep your report anonymous or request
-that we follow up with you directly. While we cannot follow up on an anonymous
-report, we will take appropriate action.
-
-Messages sent to the e-mail address or through the form will be sent only to the
-Code of Conduct Committee. Code of Conduct Committee Members are listed
-[here](./membership/CodeOfConductSubcommittee.md).
-
-## Enforcement
-
-Enforcement procedures within the GeoPandas Project follow Project Jupyter's
-[Enforcement Manual](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md).
-For information on enforcement, please view the
-[original manual](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md).
-
-Original text courtesy of the
-[Speak Up!](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html),
-[Django](https://www.djangoproject.com/conduct) and
-[Jupyter](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md)
-projects, modified by the GeoPandas Project. We are grateful to those projects
-for contributing these materials under open licensing terms for us to easily
-reuse.
-
-All content on this page is licensed under a [Creative Commons Attribution](http://creativecommons.org/licenses/by/3.0/) license.
+You can learn more about the current group members, as well as the reporting procedure **[HERE](https://numfocus.org/code-of-conduct)**

--- a/Governance.md
+++ b/Governance.md
@@ -48,7 +48,7 @@ archive of meeting notes are available within the [GeoPandas Community
 repository](https://github.com/geopandas/community).
 
 Participation in The Project follows the
-[GeoPandas Project Code of Conduct](./CodeOfConduct.md),
+[NumFOCUS Code of Conduct](./CodeOfConduct.md),
 which ensures that members of the Community treat each other with respect,
 provide an environment that welcomes participation, and provides a mechanism for
 reporting and enforcing violations.
@@ -151,8 +151,8 @@ voting rights until they become active again.
 Project Maintainers may have their write access and voting rights revoked by the
 Steering Council if they are deemed to be actively harmful to The Project's
 well-being, and attempts at communication and conflict resolution have failed.
-Depending on the nature of the conflict, if any, the Code of Conduct
-Subcommittee may be involved in conflict resolution or specifically recommend
+Depending on the nature of the conflict, if any, the NumFOCUS Code of Conduct
+Working Group may be involved in conflict resolution or specifically recommend
 revoking a Maintainer's write access and voting rights.
 
 Current and retired Project Maintainers will be
@@ -281,13 +281,6 @@ as appropriate. Like the Council as a whole, subcommittees should conduct their
 business in an open and public manner unless privacy is specifically called for.
 Private subcommittee communications should happen on the main private mailing
 list of the Council unless specifically called for.
-
-The Project shall have a Code of Conduct Subcommittee responsible for
-maintaining the [GeoPandas Code of Conduct](CodeOfConduct.md), responding to
-reports of Code of Conduct Violations, and enforcing Code of Conduct Violations.
-This subcommittee shall not be entirely composed of Steering Council Members.
-The members of the Code of Conduct Subcommittee shall be posted on the
-[Code of Conduct Subcommittee Membership document](membership/CodeOfConductSubcommittee.md).
 
 ## Changing the Governance Documents
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ project and subprojects.
 
 -   [Steering Council](./membership/SteeringCouncil.md)
 -   [Project Maintainers](./membership/Maintainers.md)
--   [Code of Conduct Committee](./membership/CodeOfConductCommittee.md)
 
 For more information about the GeoPandas project community, including recurring
 meeting schedules and other ways to engage with the project, please see the

--- a/membership/CodeOfConductCommittee.md
+++ b/membership/CodeOfConductCommittee.md
@@ -1,8 +1,0 @@
-# GeoPandas Code of Conduct Committee Members
-
--   Hannah Aizenman
--   Joris Van den Bossche
--   Martin Fleischmann
-
-See the [Code of Conduct](../CodeOfConduct.md) for more information about the
-Code of Conduct, including reporting Code of Conduct violations.


### PR DESCRIPTION
It was agreed to use NumFOCUS Code of Conduct. To do that, this PR contains necessary changes to CoC document and to the Governance document, linked to CoC subcommittee which we no longer need.